### PR TITLE
add mocking to the api

### DIFF
--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -11,7 +11,11 @@ class AuthenticatedDataSource extends RemoteGraphQLDataSource {
   willSendRequest({ request, context }) {
     request.http.headers.set('Authorization', this.userContext.authToken);
     request.http.headers.set('locale', this.userContext.locale);
-    request.http.headers.set('correlation-id', this.userContext.correlationId);
+    request.http.headers.set(
+      'that-correlation-id',
+      this.userContext.correlationId,
+    );
+    request.http.headers.set('that-enable-mocks', this.userContext.enableMocks);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -38,10 +38,13 @@ const createUserContext = (req, res, next) => {
   req.userContext = {
     locale: req.headers.locale,
     authToken: req.headers.authorization,
-    correlationId: req.headers['correlation-id']
-      ? req.headers['correlation-id']
+    correlationId: req.headers['that-correlation-id']
+      ? req.headers['that-correlation-id']
       : uuid(),
     sentry: Sentry,
+    enableMocks: req.headers['that-enable-mocks']
+      ? req.headers['that-enable-mocks']
+      : [],
   };
 
   next();


### PR DESCRIPTION
Will enable mocking on the federated api. to enable it will look for a header called `that-enable-mocks` with an array of the api's you would like mocked. example value = `events,partners` 

partially closes [ch2701]
Story details: https://app.clubhouse.io/thatconference/story/1701