### PR TITLE
handle passthrough headers better

### DIFF
--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -14,13 +14,18 @@ class AuthenticatedDataSource extends RemoteGraphQLDataSource {
   willSendRequest({ request, context }) {
     dlog('sending request (todo: add something here about request)');
 
-    if (!_.isUndefined(context) && !_.isEmpty(context)) {
+    if (!_.isNil(context)) {
       dlog('user has context, calling child services, and setting headers');
+      dlog('context %o', context);
 
-      request.http.headers.set('Authorization', context.authToken);
-      request.http.headers.set('locale', context.locale);
-      request.http.headers.set('that-correlation-id', context.correlationId);
-      request.http.headers.set('that-enable-mocks', context.enableMocks);
+      if (context.authToken)
+        request.http.headers.set('Authorization', context.authToken);
+
+      if (context.correlationId)
+        request.http.headers.set('that-correlation-id', context.correlationId);
+
+      if (context.enableMocks)
+        request.http.headers.set('that-enable-mocks', context.enableMocks);
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ function createUserContext(req, res, next) {
     logger: contextLogger,
     enableMocks: req.headers['that-enable-mocks']
       ? req.headers['that-enable-mocks']
-      : [],
+      : false,
   };
 
   next();


### PR DESCRIPTION
undefined headers were being sent through as a string of undefined rather than not getting set at all.