### PR TITLE
Pass needed headers to child api's

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,11 @@ function createUserContext(req, res, next) {
       ? req.headers['that-enable-mocks']
       : false,
   };
+  if (req.headers['that-site']) req.userContext.site = req.headers['that-site'];
+  if (req.headers.referer) req.userContext.referer = req.headers.referer;
+
+  dlog('headers %O', req.headers);
+  dlog('userContext %O', req.userContext);
 
   next();
 }

--- a/src/server.js
+++ b/src/server.js
@@ -22,11 +22,14 @@ class AuthenticatedDataSource extends RemoteGraphQLDataSource {
     if (!_.isNil(context)) {
       dlog('user has context, calling child services, and setting headers');
 
+      request.http.headers.set('that-enable-mocks', context.enableMocks);
       if (context.authToken)
         request.http.headers.set('Authorization', context.authToken);
-
-      request.http.headers.set('that-correlation-id', context.correlationId);
-      request.http.headers.set('that-enable-mocks', context.enableMocks);
+      if (context.correlationId)
+        request.http.headers.set('that-correlation-id', context.correlationId);
+      if (context.referer)
+        request.http.headers.set('X-Forwarded-For', context.referer);
+      if (context.site) request.http.headers.set('that-site', context.site);
     }
   }
 }


### PR DESCRIPTION
This pr should be merged prior to pr thatconference/that-api-sessions#81
This pr has no dependencies
Reads new header `that-site` and passes it to child api if exists
Reads header `referrer` and passes to child api as `x-forwarded-for` if exists