### PR TITLE
Bug/graphcdn rollback

### DIFF
--- a/.github/workflows/ci_onPushMain.yml
+++ b/.github/workflows/ci_onPushMain.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           npm version
           cd __build__
+          npx graphcdn version
           npx graphcdn push
         env:
           GRAPHCDN_TOKEN: ${{ secrets.GRAPHCDN_TOKEN }}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,3 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run validate
+npx graphcdn version
+npx graphcdn push

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "that-api-gateway",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "that-api-gateway",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "GPL-3.0",
       "dependencies": {
         "@apollo/gateway": "0.22.0",
@@ -41,7 +41,7 @@
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jest": "^26.0.0",
         "eslint-plugin-prettier": "^4.0.0",
-        "graphcdn": "^1.8.0",
+        "graphcdn": "^1.7.0",
         "husky": "^7.0.4",
         "jest-cli": "^27.4.7",
         "nodemon": "^2.0.15",
@@ -9252,9 +9252,9 @@
       "devOptional": true
     },
     "node_modules/graphcdn": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/graphcdn/-/graphcdn-1.8.0.tgz",
-      "integrity": "sha512-p7y1CW+/7fo/3LT4B+ITzOXyowOEqiL0SPerlq0zcqcjnfD1dIeYg5iYNrC915oBftnF16h6J6TQmpPI6DnXkA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/graphcdn/-/graphcdn-1.7.0.tgz",
+      "integrity": "sha512-zIKLP4haICvXhRJv/IJSvx+lcxwo8cpmEagLp2/Y8+BMaX6zCIOETr4agtklR8ilZQxXZN9HulUWzki4wrjKFQ==",
       "dev": true,
       "dependencies": {
         "@atomist/yaml-updater": "^1.0.2",
@@ -9264,8 +9264,7 @@
         "http-proxy-middleware": "^2.0.1",
         "is-ci": "^3.0.1",
         "random-words": "^1.1.1",
-        "slugify": "^1.4.7",
-        "zod": "^3.9.1"
+        "slugify": "^1.4.7"
       },
       "bin": {
         "graphcdn": "build/index.js"
@@ -18486,15 +18485,6 @@
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
       }
-    },
-    "node_modules/zod": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
-      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   },
   "dependencies": {
@@ -25638,9 +25628,9 @@
       "devOptional": true
     },
     "graphcdn": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/graphcdn/-/graphcdn-1.8.0.tgz",
-      "integrity": "sha512-p7y1CW+/7fo/3LT4B+ITzOXyowOEqiL0SPerlq0zcqcjnfD1dIeYg5iYNrC915oBftnF16h6J6TQmpPI6DnXkA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/graphcdn/-/graphcdn-1.7.0.tgz",
+      "integrity": "sha512-zIKLP4haICvXhRJv/IJSvx+lcxwo8cpmEagLp2/Y8+BMaX6zCIOETr4agtklR8ilZQxXZN9HulUWzki4wrjKFQ==",
       "dev": true,
       "requires": {
         "@atomist/yaml-updater": "^1.0.2",
@@ -25650,8 +25640,7 @@
         "http-proxy-middleware": "^2.0.1",
         "is-ci": "^3.0.1",
         "random-words": "^1.1.1",
-        "slugify": "^1.4.7",
-        "zod": "^3.9.1"
+        "slugify": "^1.4.7"
       },
       "dependencies": {
         "is-ci": {
@@ -32860,12 +32849,6 @@
         "tslib": "^1.9.3",
         "zen-observable": "^0.8.0"
       }
-    },
-    "zod": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
-      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-gateway",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "THAT Apollo gateway",
   "main": "index.js",
   "engines": {
@@ -70,7 +70,7 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jest": "^26.0.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "graphcdn": "^1.8.0",
+    "graphcdn": "^1.7.0",
     "husky": "^7.0.4",
     "jest-cli": "^27.4.7",
     "nodemon": "^2.0.15",


### PR DESCRIPTION
v2.2.4
Rollback graghcnd cli version to 1.7. 1.8 throwing error on push: `Expected signal to be an instanceof AbortSignal`
Added graphcdn push to Husky pre-push script to ensure cli is successful prior to pushing code.